### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+yajl (2.1.0-3) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 18:06:55 +0100
+
 yajl (2.1.0-2) unstable; urgency=medium
 
   * Change priority to optional (Closes: #758958)

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: John Stamp <jstamp@users.sourceforge.net>
 Build-Depends: debhelper (>= 9), cmake, doxygen
 Standards-Version: 3.9.5
 Homepage: http://lloyd.github.com/yajl/
-Vcs-Browser: http://github.com/jstamp/yajl
-Vcs-Git: git://github.com/jstamp/yajl.git
+Vcs-Browser: https://github.com/jstamp/yajl
+Vcs-Git: https://github.com/jstamp/yajl.git
 
 Package: libyajl2
 Architecture: any


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
