### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+yajl (2.1.0-4) UNRELEASED; urgency=low
+
+  * Apply multi-arch hints.
+    + libyajl-doc: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 30 Jun 2020 21:01:58 -0000
+
 yajl (2.1.0-3) unstable; urgency=medium
 
   [ Jelmer Vernooĳ ]

--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,7 @@ Package: libyajl-doc
 Architecture: all
 Section: doc
 Depends: ${misc:Depends}
+Multi-Arch: foreign
 Description: Yet Another JSON Library - library documentation
  A small, fast library for parsing JavaScript Object Notation (JSON).  It
  supports incremental parsing from a stream and leaves data representation to


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* libyajl-doc: Add Multi-Arch: foreign. This fixes: libyajl-doc could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/yajl/baca0425-c094-4531-81be-84da4431cbad.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a2/a0c8579f8760522b7fca10753610f3b5a4d6d1.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a8/1faf3705694e84402aaaa87e0c60af4330cf69.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c7/dc3ad6e3da1f2549c79a008d41d233e6a9083f.debug
    -rw-r--r--  root/root   /usr/share/doc/libyajl-doc/html/doxygen.png
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/02/f3f742bd36fd6191f6b867d852b370f3cef8c4.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2e/a87fd0dd5737f157f4ac838a25c357a753a948.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/58/f3c170b021a944e408fbb5dc96c49f11f640f8.debug
    -rw-r--r--  root/root   /usr/share/doc/libyajl-doc/html/doxygen.svg

No differences were encountered between the control files of package \*\*libyajl-dev\*\*
### Control files of package libyajl-doc: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}

No differences were encountered between the control files of package \*\*libyajl2\*\*
### Control files of package libyajl2-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-02f3f742bd36fd6191f6b867d852b370f3cef8c4-] {+a81faf3705694e84402aaaa87e0c60af4330cf69+}

No differences were encountered between the control files of package \*\*yajl-tools\*\*
### Control files of package yajl-tools-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-2ea87fd0dd5737f157f4ac838a25c357a753a948 58f3c170b021a944e408fbb5dc96c49f11f640f8-] {+a2a0c8579f8760522b7fca10753610f3b5a4d6d1 c7dc3ad6e3da1f2549c79a008d41d233e6a9083f+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/baca0425-c094-4531-81be-84da4431cbad/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/baca0425-c094-4531-81be-84da4431cbad/diffoscope)).
