### PR TITLE
Apply multi-arch hints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,7 @@ Package: libyajl-doc
 Architecture: all
 Section: doc
 Depends: ${misc:Depends}
+Multi-Arch: foreign
 Description: Yet Another JSON Library - library documentation
  A small, fast library for parsing JavaScript Object Notation (JSON).  It
  supports incremental parsing from a stream and leaves data representation to


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* libyajl-doc: Add Multi-Arch: foreign. This fixes: libyajl-doc could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/multiarch-fixes/pkg/yajl/97ec063e-2591-48eb-bc5c-fc0dfa484702.