### PR TITLE
Nmu debbug1039984 CVE 2023 33460

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+yajl (2.1.0-3.1) UNRELEASED; urgency=medium
+
+  * Non-maintainer upload.
+  * Import upstream patch for CVE-2023-33460. (Closes: #1039984)
+  * Fix d/control Homepage field (Closes: #1040034)
+
+ -- Tobias Frost <tobi@debian.org>  Sat, 01 Jul 2023 14:38:32 +0200
+
 yajl (2.1.0-3) unstable; urgency=medium
 
   [ Jelmer Vernooĳ ]

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: John Stamp <jstamp@users.sourceforge.net>
 Build-Depends: debhelper (>= 11), cmake, doxygen
 Standards-Version: 4.2.1
 Rules-Requires-Root: no
-Homepage: http://lloyd.github.com/yajl/
+Homepage: https://lloyd.github.io/yajl/
 Vcs-Browser: https://github.com/jstamp/yajl
 Vcs-Git: https://github.com/jstamp/yajl.git
 

--- a/debian/patches/CVE-2023-33460.patch
+++ b/debian/patches/CVE-2023-33460.patch
@@ -1,8 +1,8 @@
-From 23a122eddaa28165a6c219000adcc31ff9a8a698 Mon Sep 17 00:00:00 2001
-From: "zhang.jiujiu" <282627424@qq.com>
-Date: Tue, 7 Dec 2021 22:37:02 +0800
-Subject: [PATCH] fix memory leaks
-
+Description: Fix for CVE-2023-33460a
+ Memory leak in yajl 2.1.0 with use of yajl_tree_parse function
+Origin: https://github.com/openEuler-BaseService/yajl/commit/23a122eddaa28165a6c219000adcc31ff9a8a698
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039984
+Bug: https://github.com/lloyd/yajl/issues/250
 ---
  src/yajl_tree.c | 3 +++
  1 file changed, 3 insertions(+)

--- a/debian/patches/CVE-2023-33460.patch
+++ b/debian/patches/CVE-2023-33460.patch
@@ -1,0 +1,21 @@
+From 23a122eddaa28165a6c219000adcc31ff9a8a698 Mon Sep 17 00:00:00 2001
+From: "zhang.jiujiu" <282627424@qq.com>
+Date: Tue, 7 Dec 2021 22:37:02 +0800
+Subject: [PATCH] fix memory leaks
+
+---
+ src/yajl_tree.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/src/yajl_tree.c
++++ b/src/yajl_tree.c
+@@ -445,6 +445,9 @@
+              YA_FREE(&(handle->alloc), internal_err_str);
+         }
+         yajl_free (handle);
++	//If the requested memory is not released in time, it will cause memory leakage
++	if(ctx.root)
++	     yajl_tree_free(ctx.root);
+         return NULL;
+     }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 dynamically-link-tools.patch
 multiarch.patch
+CVE-2023-33460.patch


### PR DESCRIPTION
This NMU has been uploaded to DELAYED/10, ETA around  Jul 11 15:00 CEST.
If you merge this earlier, I'll accelerate the upload. 

[NMU Bug in the Debian BTS](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1040039)